### PR TITLE
[feat]낙찰된 물품(판매) 페이지 버튼들 기능 구현

### DIFF
--- a/src/main/java/com/metacoding/web_project/bid/BidService.java
+++ b/src/main/java/com/metacoding/web_project/bid/BidService.java
@@ -127,6 +127,7 @@ public class BidService {
         // ParticipatingAuctionDTO로 변환
         List<BidResponse.ParticipatingAuctionDTO> participatingAuctionDtoList = new ArrayList<>();
 
+
         for (Bid bid : bidList) {
             // 최고 입찰가 조회
             Bid bestPrice = bidRepository.findMaxPrice(bid.getGoods().getId());

--- a/src/main/java/com/metacoding/web_project/transaction/Transaction.java
+++ b/src/main/java/com/metacoding/web_project/transaction/Transaction.java
@@ -39,8 +39,12 @@ public class Transaction {
     @Column(nullable = false)
     private Integer sellerStatus;
 
+    // 0 : 거래 취소 버튼 누르기 전
+    // 1 : 거래 취소 버튼 누른 후
+    @Column(nullable = false)
+    private Integer transactionStatus;
 
-
+    
     @Column(nullable = false)
     private Integer successPrice;
 
@@ -63,12 +67,15 @@ public class Transaction {
         this.updatedAt = Timestamp.valueOf(LocalDateTime.now());
     }
 
-    public void updateStatus(Integer buyerStatus, Integer sellerStatus, Integer deliveryNum) {
+    public void updateStatus(Integer buyerStatus, Integer sellerStatus, Integer transactionStatus, Integer deliveryNum) {
         if (buyerStatus != null) {
             this.buyerStatus = buyerStatus;
         }
         if (sellerStatus != null) {
             this.sellerStatus = sellerStatus;
+        }
+        if (transactionStatus != null) {
+            this.transactionStatus = transactionStatus;
         }
         if (deliveryNum != null) {
             this.deliveryNum = deliveryNum;

--- a/src/main/java/com/metacoding/web_project/transaction/TransactionController.java
+++ b/src/main/java/com/metacoding/web_project/transaction/TransactionController.java
@@ -7,10 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -39,6 +36,33 @@ public class TransactionController {
         return "complete-auction";
     }
 
+    // 낙찰된 물품(판매) 송장 번호 등록 -> transaction_tb 테이블의 delivery_number update
+    @PostMapping("/deliveryNumber/update")
+    public String deliveryNumUpdate(TransactionRequest.UpdateDeliveryNumberDTO updateDeliveryNumberDTO) {
+        transactionService.updateDeliveryNumber(updateDeliveryNumberDTO);
+        return "redirect:/myPage-complete-auction";
+    }
+
+    // 낙찰된 물품(판매) 판매 확정하기 -> transaction_tb 테이블의 seller_status = 1로 update
+    @PostMapping("/sellerStatus/update")
+    @ResponseBody
+    public ResponseEntity<?> updateSellerStatus(@RequestBody TransactionRequest.UpdateSellerStatusDTO updateSellerStatusDTO) {
+        transactionService.updateSellerStatus(updateSellerStatusDTO);
+
+        CommonResp resp = new CommonResp(true, "판매 확정 되었습니다.", null);
+        return ResponseEntity.ok(resp);    
+    }
+
+    // 낙찰된 물품(판매) 판매 취소하기 -> transaction_tb 테이블의 transaction_status = 1로 update
+    @PostMapping("/transactionStatus/update")
+    @ResponseBody
+    public ResponseEntity<?> updateTransactionStatus(@RequestBody TransactionRequest.UpdateTransactionStatusDTO updateTransactionStatusDTO) {
+        transactionService.updateTransactionStatus(updateTransactionStatusDTO);
+
+        CommonResp resp = new CommonResp(true, "판매 취소 되었습니다.", null);
+        return ResponseEntity.ok(resp);
+    }
+
     // 낙찰된 물품(구매) 화면 열기 - 구매 완료 / 구매 확정 누름
     @GetMapping("/myPage-participated-auction")
     public String participatedAuction(Model model) {
@@ -46,7 +70,6 @@ public class TransactionController {
         model.addAttribute("models", participatedAuctionList);
         return "participated-auction";
     }
-
 
     // 경매 종료 시 transaction_tb에 경매 완료된 데이터 저장
     @PostMapping("/goods-detail/saveTransaction")

--- a/src/main/java/com/metacoding/web_project/transaction/TransactionRepository.java
+++ b/src/main/java/com/metacoding/web_project/transaction/TransactionRepository.java
@@ -47,11 +47,10 @@ public class TransactionRepository {
         return count.intValue();
     }
 
-
-    // 낙찰 완료된 물품 목록 DTO(판매자 입장 / 판매 확정 안 누른 상태)
+    // 낙찰된 물품(판매) 목록 조회 (판매 확정 누름, 안 누름 전부 포함)
     public List<Transaction> findBySellerIdNotConfirmOfSell(Integer id) {
         String sql = """
-                select * from transaction_tb where seller_id = ? and seller_status = 0
+                select * from transaction_tb where seller_id = ?
                 """;
 
         Query q = em.createNativeQuery(sql, Transaction.class);
@@ -60,7 +59,7 @@ public class TransactionRepository {
         return q.getResultList();
     }
 
-    // 낙찰된 물품(구매) 목록 DTO(구매 확정 누름, 안누름 전부 포함)
+    // 낙찰된 물품(구매) 목록 조회(구매 확정 누름, 안 누름 전부 포함)
     public List<Transaction> findByBuyerIdForAllBuy(Integer id) {
         String sql = """
                 select * from transaction_tb where buyer_id = ?
@@ -70,5 +69,9 @@ public class TransactionRepository {
         q.setParameter(1, id);
 
         return q.getResultList();
+    }
+
+    public Optional<Transaction> findById(Integer id) {
+        return Optional.ofNullable(em.find(Transaction.class, id));
     }
 }

--- a/src/main/java/com/metacoding/web_project/transaction/TransactionRequest.java
+++ b/src/main/java/com/metacoding/web_project/transaction/TransactionRequest.java
@@ -34,6 +34,29 @@ public class TransactionRequest {
                     .build();
 
         }
+    }
 
+    // 낙찰된 물품(판매) 화면 - 송장번호등록 DTO
+    // transaction_tb 테이블의 delivery_num update
+    @Data
+    public static class UpdateDeliveryNumberDTO {
+        private Integer transactionId;
+        private Integer deliveryNumber;
+    }
+
+    // 낙찰된 물품(판매) 화면 - 판매 확정하기 DTO
+    // transaction_tb 테이블의 seller_status = 1로 update
+    @Data
+    public static class UpdateSellerStatusDTO {
+        private Integer transactionId;
+        private Integer sellerStatus;
+    }
+
+    // 낙찰된 물품(판매) 화면 - 판매 취소하기 DTO
+    // transaction_tb 테이블의 transaction_status = 1로 update
+    @Data
+    public static class UpdateTransactionStatusDTO {
+        private Integer transactionId;
+        private Integer transactionStatus;
     }
 }

--- a/src/main/java/com/metacoding/web_project/transaction/TransactionResponse.java
+++ b/src/main/java/com/metacoding/web_project/transaction/TransactionResponse.java
@@ -5,8 +5,6 @@ import lombok.Data;
 
 public class TransactionResponse {
 
-    
-
     @Data
     public static class TransactionDTO {
         private String title;
@@ -36,7 +34,7 @@ public class TransactionResponse {
         }
     }
 
-    // 낙찰된 물품(판매) 목록 DTO(판매 확정 안 누른 상태)
+    // 낙찰된 물품(판매) 목록 DTO(판매 확정 누름, 안 누름 전부 포함)
     @Data
     public static class CompleteAuctionDTO {
         private Integer id;
@@ -45,8 +43,11 @@ public class TransactionResponse {
         private String goodsImgUrl;
         private String updatedAt;
         private Integer successPrice;
-        private Integer sellerStatus = 0; // 판매 확정 안 누른 상태
         private String buyerAddress;
+        private String deliveryNum;
+        private Boolean sellerStatus = false; // 판매 확정 상태 (false = 안 누름, true = 누름)
+        private Boolean buyerStatus = false; // 구매 확정 상태 (false = 안 누름, true = 누름)
+        private Boolean transactionStatus = false; // 판매 취소 상태 (false = 안 누름, true = 누름)
 
         public CompleteAuctionDTO(Transaction transaction) {
             this.id = transaction.getId();
@@ -55,8 +56,26 @@ public class TransactionResponse {
             this.goodsImgUrl = transaction.getGoods().getImgUrl();
             this.updatedAt = FormatDate.formatToyyyypMMpdd(transaction.getUpdatedAt());
             this.successPrice = transaction.getSuccessPrice();
-            this.sellerStatus = transaction.getSellerStatus();
             this.buyerAddress = transaction.getBuyer().getAddr();
+
+            if (transaction.getDeliveryNum() != null) {
+                this.deliveryNum = String.valueOf(transaction.getDeliveryNum());
+
+            } else {
+                this.deliveryNum = "송장번호가 등록되지 않았습니다.";
+            }
+
+            if (transaction.getSellerStatus() == 1) {
+                this.sellerStatus = true;
+            }
+
+            if (transaction.getBuyerStatus() == 1) {
+                this.buyerStatus = true;
+            }
+
+            if (transaction.getTransactionStatus() == 1) {
+                this.transactionStatus = true;
+            }
         }
     }
 
@@ -70,7 +89,9 @@ public class TransactionResponse {
         private String goodsImgUrl;
         private Integer successPrice;
         private String deliveryNum;
-        private Boolean buyerStatus = false;
+        private Boolean sellerStatus = false; // 판매 확정 상태 (false = 안 누름, true = 누름)
+        private Boolean buyerStatus = false; // 구매 확정 상태 (false = 안 누름, true = 누름)
+        private Boolean transactionStatus = false; // 판매 취소 상태 (false = 안 누름, true = 누름)
 
         public ParticipatedAuctionDTO(Transaction transaction) {
             this.id = transaction.getId();
@@ -84,11 +105,19 @@ public class TransactionResponse {
                 this.deliveryNum = String.valueOf(transaction.getDeliveryNum());
 
             } else {
-                this.deliveryNum = "";
+                this.deliveryNum = "등록된 송장 번호가 없습니다.";
+            }
+
+            if (transaction.getSellerStatus() == 1) {
+                this.sellerStatus = true;
             }
 
             if (transaction.getBuyerStatus() == 1) {
                 this.buyerStatus = true;
+            }
+
+            if (transaction.getTransactionStatus() == 1) {
+                this.transactionStatus = true;
             }
         }
     }

--- a/src/main/java/com/metacoding/web_project/transaction/TransactionService.java
+++ b/src/main/java/com/metacoding/web_project/transaction/TransactionService.java
@@ -1,6 +1,7 @@
 package com.metacoding.web_project.transaction;
 
 import com.metacoding.web_project._core.util.PageUtil;
+import com.metacoding.web_project._core.error.ex.Exception404;
 import com.metacoding.web_project.bid.Bid;
 import com.metacoding.web_project.bid.BidRepository;
 import com.metacoding.web_project.user.User;
@@ -67,7 +68,7 @@ public class TransactionService {
         return transactionRepository.findTransactionsCount(query);
     }
 
-    // 낙찰된 물품(판매) 화면 열기 - 판매 확정 안 누름
+    // 낙찰된 물품(판매) 화면 열기 - 판매 확정 누름, 안 누름 포함
     @Transactional
     public List<TransactionResponse.CompleteAuctionDTO> completeAuctionList() {
         
@@ -81,6 +82,33 @@ public class TransactionService {
             completeAuctionDTOList.add(new TransactionResponse.CompleteAuctionDTO(transaction));
         }
         return completeAuctionDTOList;
+    }
+
+    // 낙찰된 물품(판매) 화면 - 송장번호등록(transaction_tb 테이블의 delivery_num update)
+    @Transactional
+    public void updateDeliveryNumber(TransactionRequest.UpdateDeliveryNumberDTO updateDeliveryNumberDTO) {
+        Transaction transaction = transactionRepository.findById(updateDeliveryNumberDTO.getTransactionId())
+                .orElseThrow(() -> new Exception404("해당 물품이 없습니다."));
+
+        transaction.updateStatus(null, null, null, updateDeliveryNumberDTO.getDeliveryNumber());
+    }
+
+    // 낙찰된 물품(판매) 화면 - 판매 확정하기(transaction_tb 테이블의 seller_status = 1로 update)
+    @Transactional
+    public void updateSellerStatus(TransactionRequest.UpdateSellerStatusDTO updateSellerStatusDTO) {
+        Transaction transaction = transactionRepository.findById(updateSellerStatusDTO.getTransactionId())
+                .orElseThrow(() -> new Exception404("해당 물품이 없습니다."));
+
+        transaction.updateStatus(null, updateSellerStatusDTO.getSellerStatus(), null, null);
+    }
+
+    // 낙찰된 물품(판매) 화면 - 판매 취소하기(transaction_tb 테이블의 transaction_status = 1로 update)
+    @Transactional
+    public void updateTransactionStatus(TransactionRequest.UpdateTransactionStatusDTO updateTransactionStatusDTO) {
+        Transaction transaction = transactionRepository.findById(updateTransactionStatusDTO.getTransactionId())
+                .orElseThrow(() -> new Exception404("해당 물품이 없습니다."));
+
+        transaction.updateStatus(null, null, updateTransactionStatusDTO.getTransactionStatus(), null);
     }
 
     // 낙찰된 물품(구매) 화면 열기 - 구매 확정 누름, 안 누름 다 포함

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -65,7 +65,7 @@ insert into bid_tb(buyer_id,goods_id,try_price,created_at) values (1,2,21000,now
 insert into bid_tb(buyer_id,goods_id,try_price,created_at) values (2,3,5500,now());
 insert into bid_tb(buyer_id,goods_id,try_price,created_at) values (2,4,130000,now());
 
-insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, success_price, updated_at) values (2, 2, 3, 0, 1, 50000, now());
+insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, transaction_status, success_price, updated_at) values (2, 2, 3, 0, 1, 0,50000, now());
 
 
 insert into bid_tb(buyer_id,goods_id,try_price,created_at) values (2,1,3000,now());
@@ -76,15 +76,15 @@ insert into bid_tb(buyer_id,goods_id,try_price,created_at) values (1,1,4000,now(
 insert into bid_tb(buyer_id,goods_id,try_price,created_at) values (1,1,5000,now());
 
 -- transaction_tb 더미데이터
-insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, success_price, updated_at) values (2, 2, 3, 0, 1, 50000, now());
-insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, success_price, updated_at) values (1, 3, 1, 0, 0, 86000, now());
-insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, success_price, updated_at) values (4, 2, 1, 0, 0, 3000, now());
-insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, success_price, updated_at) values (2, 2, 1, 0, 1, 100000, now());
-insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, success_price, updated_at) values (3, 1, 2, 0, 1, 50000, now());
-insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, success_price, updated_at) values (7, 1, 3, 0, 1, 9200, now());
-insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, success_price, updated_at) values (4, 1, 2, 0, 1, 45000, now());
-insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, success_price, updated_at) values (5, 1, 3, 1, 1, 7000, now());
-insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, success_price, updated_at) values (2, 1, 2, 1, 1, 6500, now());
+insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, transaction_status, success_price, updated_at) values (2, 2, 3, 0, 1, 0, 50000, now());
+insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, transaction_status, success_price, updated_at) values (1, 3, 1, 0, 0, 0,86000, now());
+insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, transaction_status, success_price, updated_at) values (4, 2, 1, 0, 0, 0,3000, now());
+insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, transaction_status, success_price, updated_at) values (2, 2, 1, 1, 1, 0,100000, now());
+insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, transaction_status, success_price, updated_at) values (3, 1, 2, 0, 1, 0,50000, now());
+insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, transaction_status, success_price, updated_at) values (7, 1, 3, 0, 1, 0,9200, now());
+insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, transaction_status, success_price, updated_at) values (4, 1, 2, 0, 1, 0,45000, now());
+insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, transaction_status, success_price, updated_at) values (5, 1, 3, 1, 1, 0,7000, now());
+insert into transaction_tb(goods_id, buyer_id, seller_id, buyer_status, seller_status, transaction_status, success_price, updated_at) values (2, 1, 2, 1, 1, 0,6500, now());
 
 --report_tb 더미데이터
 insert into report_tb(reporter_id, reported_id, reason, transaction_id, status) values (3, 2, '아 자바스크립트', 1, 0);

--- a/src/main/resources/templates/being-auctioned.mustache
+++ b/src/main/resources/templates/being-auctioned.mustache
@@ -33,8 +33,8 @@
                               <input type="hidden" name="id" id="{{id}}">
                               <div>카테고리 : {{categoryName}}</div>
                               <div>경매 종료 일시 : {{endAt}}</div>
-                              <div>시작 입찰가 : {{startingPrice}}</div>
-                              <div>현재 입찰가 : {{tryPrice}}</div>
+                              <div>시작 입찰가 : {{startingPrice}}원</div>
+                              <div>현재 입찰가 : {{tryPrice}}원</div>
                               <div class="btn-group mt-1">
                                   <button type="button" class="btn btn-custom btn-sm" onclick = "deleteGoods({{goodsId}})">경매 취소</button>
                                   <button type="button" class="btn btn-custom btn-sm">조기 종료</button>

--- a/src/main/resources/templates/complete-auction.mustache
+++ b/src/main/resources/templates/complete-auction.mustache
@@ -8,25 +8,23 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <link rel="stylesheet" type="text/css" href="/css/nav.css">
     <link rel="stylesheet" type="text/css" href="/css/header.css">
-
     <link rel="stylesheet" href="/css/myPage.css">
 </head>
 <body>
 
-
 {{>layout/header}}
 <div class="container d-flex mt-5">
     {{>layout/mypage-menu}}
-      <div class="box">
+    <div class="box">
         <div class="title-box">
-          <h2>낙찰된 물품(판매)</h2>
+            <h2>낙찰된 물품(판매)</h2>
         </div>
         <div class="item-list mt-5">
 
             {{#models}}
                 <div class="card mb-3">
                     <div class="card-image">
-                        <img src="{{goodsImgUrl}}" class="card-img-top" />
+                        <img src="{{goodsImgUrl}}" class="card-img-top"/>
                     </div>
                     <div class="card-body mt-2">
                         <h4 class="card-title">{{title}}</h4>
@@ -34,12 +32,36 @@
                             <input type="hidden" name="id" id="{{id}}">
                             <div>카테고리 : {{categoryName}}</div>
                             <div>낙찰 일시 : {{updatedAt}}</div>
-                            <div>낙찰가 : {{successPrice}}</div>
+                            <div>낙찰가 : {{successPrice}}원</div>
                             <div>구매자 주소 : {{buyerAddress}}</div>
+                            <div>송장번호 : {{deliveryNum}}</div>
+                            <div>
+                                {{#buyerStatus}} <!-- buyerStatus = 1일때 -->
+                                    구매 확정됨
+                                {{/buyerStatus}}
+                                {{^buyerStatus}} <!-- buyerStatus = 0일때 -->
+                                    구매 확정 대기중
+                                {{/buyerStatus}}
+                            </div>
+                            <div>
+                                <!-- transactionStatus = 1일때만 판매 취소 문구가 보이도록 -->
+                                {{#transactionStatus}}
+                                    판매 취소
+                                {{/transactionStatus}}
+                            </div>
                             <div class="btn-group mt-1">
-                                <button type="button" class="btn btn-custom btn-sm">송장번호 등록</button>
-                                <button type="button" class="btn btn-custom btn-sm">판매 확정</button>
-                                <button type="button" class="btn btn-custom btn-sm">판매 취소</button>
+                                <button type="button" class="btn btn-custom btn-sm"
+                                        onclick="addNumber({{id}})"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#deliveryNumberModal">
+                                    송장번호등록
+                                </button>
+                                {{^sellerStatus}} <!-- sellerStatus = 0일때만 판매 확정 버튼이 보이도록 -->
+                                    <button type="button" class="btn btn-custom btn-sm" onclick="confirmSale({{id}})">판매 확정</button>
+                                {{/sellerStatus}}
+                                {{^transactionStatus}} <!-- transactionStatus = 0일때만 판매 취소 버튼이 보이도록 -->
+                                    <button type="button" class="btn btn-custom btn-sm" onclick="cancelSale({{id}})">판매 취소</button>
+                                {{/transactionStatus}}
                             </div>
                         </div>
                     </div>
@@ -47,8 +69,90 @@
             {{/models}}
 
         </div>
-      </div>
     </div>
+</div>
+
+<!-- 송장번호 등록 모달창 -->
+<div class="modal fade" id="deliveryNumberModal" tabindex="-1" aria-labelledby="deliveryNumberModalLabel"
+     aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deliveryNumberModalLabel">송장번호등록</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form action="/deliveryNumber/update" method="post">
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="deliveryNumber" class="form-label">송장번호</label>
+                        <input type="number" class="form-control" id="deliveryNumber" name="deliveryNumber"
+                               placeholder="-없이 숫자만 입력하세요" required>
+                    </div>
+                    <!-- 숨겨진 필드에 transactionId 설정 -->
+                    <input type="hidden" id="hiddenId" name="transactionId">
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+                    <button type="submit" class="btn btn-primary">등록</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script>
+    // 송장번호등록을 위한 모달창에 해당 물품의 transactionId값 넣기
+    function addNumber(transactionId){
+        document.getElementById('hiddenId').value = transactionId;
+    }
+
+    // 판매 확정하기
+    function confirmSale(transactionId) {
+        if (confirm('판매를 확정하시겠습니까?')) {
+            fetch('/sellerStatus/update', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    transactionId: transactionId,
+                    sellerStatus: 1
+                })
+            }).then(response => {
+                if (response.ok) {
+                    alert('판매가 확정되었습니다.');
+                    location.reload();
+                } else {
+                    alert('판매 확정에 실패했습니다.');
+                }
+            });
+        }
+    }
+
+    // 판매 취소하기
+    function cancelSale(transactionId) {
+        if (confirm('판매를 취소하시겠습니까?')) {
+            fetch('/transactionStatus/update', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    transactionId: transactionId,
+                    transactionStatus: 1
+                })
+            }).then(response => {
+                if (response.ok) {
+                    alert('판매가 취소되었습니다.');
+                    location.reload();
+                } else {
+                    alert('판매 취소에 실패했습니다.');
+                }
+            });
+        }
+    }
+</script>
+
 {{>layout/footer}}
-  </body>
+</body>
 </html>

--- a/src/main/resources/templates/participated-auction.mustache
+++ b/src/main/resources/templates/participated-auction.mustache
@@ -35,7 +35,7 @@
                             <input type="hidden" name="id" id="{{id}}" />
                             <div>판매자 : {{sellerName}}</div>
                             <div>카테고리 : {{categoryName}}</div>
-                            <div>낙찰가 : {{successPrice}}</div>
+                            <div>낙찰가 : {{successPrice}}원</div>
                             <div>송장번호 확인 : {{deliveryNum}}</div>
                             <div class="btn-group mt-1">
                                 {{^buyerStatus}} <!-- buyerStatus = 0일때만 구매 확정 버튼이 보이도록 -->

--- a/src/main/resources/templates/participating-auction.mustache
+++ b/src/main/resources/templates/participating-auction.mustache
@@ -34,8 +34,8 @@
                             <input type="hidden" name="id" id="{{id}}">
                             <div>판매자 : {{sellerName}}</div>
                             <div>카테고리 : {{categoryName}}</div>
-                            <div>최고 입찰가 : {{maxPrice}}</div>
-                            <div>내가 입찰한 가격 : {{buyerTryPrice}}</div>
+                            <div>최고 입찰가 : {{maxPrice}}원</div>
+                            <div>내가 입찰한 가격 : {{buyerTryPrice}}원</div>
                             <div class="btn-group mt-1">
                                 <button type="button" class="btn btn-custom btn-sm">입찰 취소</button>
                                 <button type="button" class="btn btn-custom btn-sm">입찰 금액 수정</button>


### PR DESCRIPTION
Transaction 클래스(엔티티)에 transactionStatus 필드 추가 
- transactionStatus = 0 은 판매/구매 취소 버튼 누르기 전
- transactionStatus = 1 은 판매/구매 취소 버튼 누른 후

Transaction 클래스 - updateStatus 메서드 수정 (transactionStatus 추가)

data.sql파일에서 transaction_tb의 insert sql문에 transaction_status 컬럼 추가해서 전부 수정

TransactionRepository 클래스 - 낙찰된 물품(판매) 목록 나타내는 메서드 sql문 수정

complete-auction.mustache 파일 
- 낙찰된 물품(판매) 페이지의 버튼들 기능 구현을 위한 <script> 추가
- 송장번호등록 (송장번호등록되면 번호 확인할 수 있도록 문구 추가)
- 판매 확정 (판매 확정되면 버튼 사라지도록 수정)
- 판매 취소 (판매 취소되면 버튼 사라지도록 수정)
- 구매 확정 여부 알 수 있도록 문구 추가