### PR TITLE
[fix] ] 경매가 종료된 물품은 물품 목록 리스트 페이지에서 출력하지 않도록 변경

### DIFF
--- a/src/main/java/com/metacoding/web_project/goods/GoodsResponse.java
+++ b/src/main/java/com/metacoding/web_project/goods/GoodsResponse.java
@@ -58,6 +58,8 @@ public class GoodsResponse {
       private String tryPrice;
       private String endAt;
 
+      private boolean sellAvailable = true;
+
         @Builder
         public GoodsDTO(Goods goods, Integer bidTryPrice) {
             this.id = goods.getId();
@@ -68,6 +70,11 @@ public class GoodsResponse {
             this.startingPrice = goods.getStartingPrice();
             this.tryPrice = bidTryPrice==0? "입찰자가 없습니다.":"최고 입찰가: "+String.valueOf(bidTryPrice);
             this.endAt = formatRemainingTime(goods.getEndAt());
+            if (formatRemainingTime(goods.getEndAt()).equals("경매가 종료되었습니다.")) {
+                sellAvailable = false;
+            }
+
+
         }
 
 

--- a/src/main/resources/templates/goods-list.mustache
+++ b/src/main/resources/templates/goods-list.mustache
@@ -46,22 +46,25 @@
             <hr>
             <div class="my__list__item__box2">
                 {{#goods}}
-                <a href="/goods-detail/{{id}}" style="text-decoration: none; color: #f96506;">
-                    <div class="card" style="border: 2px solid orange">
-                        <input type="hidden" class="id" value="{{id}}">
-                        <img class="card__img__top" src="{{imgUrl}}" alt="ListCard image">
-                        <div class="card__body">
-                            <div style="min-height: 100px">
-                                <h4 class="card__title" style="margin-bottom: 15px">{{title}}</h4>
+                    {{#sellAvailable}}
+                        <a href="/goods-detail/{{id}}" style="text-decoration: none; color: #f96506;">
+                            <div class="card" style="border: 2px solid orange">
+                                <input type="hidden" class="id" value="{{id}}">
+                                <img class="card__img__top" src="{{imgUrl}}" alt="ListCard image">
+                                <div class="card__body">
+                                    <div style="min-height: 100px">
+                                        <h4 class="card__title" style="margin-bottom: 15px">{{title}}</h4>
+                                    </div>
+                                    <p class="card__text">판매자: {{seller}}</p>
+                                    <p class="card__text">카테고리: {{category}}</p>
+                                    <p class="card__text">시작 입찰가: {{startingPrice}}</p>
+                                    <p class="card__text">{{tryPrice}}</p>
+                                    <p class="card__text">{{endAt}}</p>
+                                </div>
                             </div>
-                        <p class="card__text">판매자: {{seller}}</p>
-                        <p class="card__text">카테고리: {{category}}</p>
-                        <p class="card__text">시작 입찰가: {{startingPrice}}</p>
-                        <p class="card__text">{{tryPrice}}</p>
-                        <p class="card__text">{{endAt}}</p>
-                        </div>
-                    </div>
-                </a>
+                        </a>
+                    {{/sellAvailable}}
+
                 {{/goods}}
                 <div class="t1-btn-box">
                     <button type="button" class="t1-more-btn btn btn-secondary" onclick="moreList()">더보기</button>


### PR DESCRIPTION
경매가 종료된 물품은 물품 목록 리스트 페이지에서 출력하지 않도록 변경 :
뷰 반환할 때 주는 model에 sellAvailabe 필드 추가 (기본적으로 true 값을 가지고 있으나, 경매가 종료되었으면 false로 변경됨)